### PR TITLE
Fix argument order in signinCheck for validation

### DIFF
--- a/src/Authentication.hs
+++ b/src/Authentication.hs
@@ -31,5 +31,5 @@ signinCheck :: (Database m, Hasher m) => Email -> Password -> m Bool
 signinCheck email pass = do
   mUser <- lookupUser email
   case mUser of
-    Just (User _ uhash) -> validatePassword uhash pass
+    Just (User _ uhash) -> validatePassword pass uhash
     Nothing -> pure False


### PR DESCRIPTION
There was a bug where we used pass and pass hash in the wrong order.
(Should've used newtypes instead of aliases)